### PR TITLE
Fix compiler warning -Wlto-type-mismatch

### DIFF
--- a/softhddev.c
+++ b/softhddev.c
@@ -83,7 +83,7 @@ static void DumpMpeg(const uint8_t * data, int size);
 
 extern int ConfigAudioBufferTime;	///< config size ms of audio buffer
 extern int DisableOglOsd;		///< disable OpenGL OSD
-extern int ConfigVideoClearOnSwitch;	///< clear decoder on channel switch
+extern char ConfigVideoClearOnSwitch;	///< clear decoder on channel switch
 char ConfigStartX11Server;		///< flag start the x11 server
 static signed char ConfigStartSuspended;	///< flag to start in suspend mode
 static char ConfigFullscreen;		///< fullscreen modus


### PR DESCRIPTION
fix a compiler warning by aliging type defined in 2 files differently:

- softhddev.c:86:12 (int -> char)
- softhddevice.cpp:107:6 (char)