### PR TITLE
almost no more droping/duping after sync on SD + many fixes

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -145,7 +145,7 @@ static int AudioSkip;			///< skip audio to sync to video
 
 static const int AudioBytesProSample = 2;	///< number of bytes per sample
 
-static int AudioBufferTime = 336;	///< audio buffer time in ms
+static int AudioBufferTime = 128;	///< audio buffer time in ms
 
 #ifdef USE_AUDIO_THREAD
 static pthread_t AudioThread;		///< audio play thread
@@ -2823,7 +2823,7 @@ void AudioPause(void)
 void AudioSetBufferTime(int delay)
 {
     if (!delay) {
-	delay = 336;
+	delay = 128;
     }
     AudioBufferTime = delay;
 }

--- a/video.c
+++ b/video.c
@@ -573,7 +573,7 @@ extern pthread_cond_t AudioStartCond;	///< condition variable
 volatile int EnoughVideo;
 extern volatile int EnoughAudio;
 volatile VideoResolutions VideoResolution;
-static int VideoStartThreshold = 15;
+static int VideoStartThreshold = 16;
 void AudioDelayms(int);
 //----------------------------------------------------------------------------
 //	Common Functions

--- a/video.c
+++ b/video.c
@@ -6795,8 +6795,10 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 		goto out;
 	    }
 	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
-		Debug(3,"drop video\n");
-		VaapiAdvanceDecoderFrame(decoder);
+		if (!(decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced)) {
+		    Debug(3,"drop video\n");
+		    VaapiAdvanceDecoderFrame(decoder);
+		}
 		goto skip_sync;
 	    }
 	}
@@ -10941,8 +10943,10 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 		goto out;
 	    }
 	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
-		Debug(3,"drop video\n");
-		VdpauAdvanceDecoderFrame(decoder);
+		if (!(decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced)) {
+		    Debug(3,"drop video\n");
+		    VdpauAdvanceDecoderFrame(decoder);
+		}
 		goto skip_sync;
 	    }
 	}
@@ -13513,8 +13517,10 @@ static void CuvidSyncDecoder(CuvidDecoder * decoder)
 		goto out;
 	    }
 	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
-		Debug(3,"drop video\n");
-		CuvidAdvanceDecoderFrame(decoder);
+		if (!(decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced)) {
+		    Debug(3,"drop video\n");
+		    CuvidAdvanceDecoderFrame(decoder);
+		}
 		goto skip_sync;
 	    }
 	}

--- a/video.c
+++ b/video.c
@@ -6826,7 +6826,7 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 	    ++decoder->FramesDuped;
 	    decoder->SyncCounter = 1;
 	    goto out;
-	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + 2 * decoder->Interlaced) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + decoder->Interlaced) { // double advance possible?
 	    err = VaapiMessage(3, "video: speed up video, droping frame\n");
 	    ++decoder->FramesDropped;
 	    VaapiAdvanceDecoderFrame(decoder);
@@ -10972,7 +10972,7 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 	    ++decoder->FramesDuped;
 	    decoder->SyncCounter = 1;
 	    goto out;
-	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + 2 * decoder->Interlaced) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + decoder->Interlaced) { // double advance possible?
 	    err = VdpauMessage(3, "video: speed up video, droping frame\n");
 	    ++decoder->FramesDropped;
 	    VdpauAdvanceDecoderFrame(decoder);
@@ -13544,7 +13544,7 @@ static void CuvidSyncDecoder(CuvidDecoder * decoder)
 	    ++decoder->FramesDuped;
 	    decoder->SyncCounter = 1;
 	    goto out;
-	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + 2 * decoder->Interlaced) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) > 1 + decoder->Interlaced) { // double advance possible?
 	    err = CuvidMessage(3, "video: speed up video, droping frame\n");
 	    ++decoder->FramesDropped;
 	    CuvidAdvanceDecoderFrame(decoder);

--- a/video.c
+++ b/video.c
@@ -6831,7 +6831,7 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 	    ++decoder->FramesDropped;
 	    VaapiAdvanceDecoderFrame(decoder);
 	    decoder->SyncCounter = 1;
-	} else if (diff < lower_limit * 90 && !atomic_read(&decoder->SurfacesFilled) && !IsReplay()) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced && !IsReplay()) {
 	    err = VaapiMessage(3, "video: speed up audio, delay audio\n");
 	    AudioDelayms(-diff / 90 + 55);
 	}
@@ -10979,7 +10979,7 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 	    ++decoder->FramesDropped;
 	    VdpauAdvanceDecoderFrame(decoder);
 	    decoder->SyncCounter = 1;
-	} else if (diff < lower_limit * 90 && !atomic_read(&decoder->SurfacesFilled) && !IsReplay()) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced && !IsReplay()) {
 	    err = VdpauMessage(3, "video: speed up audio, delay audio\n");
 	    AudioDelayms(-diff / 90 + 55);
 	}
@@ -13553,7 +13553,7 @@ static void CuvidSyncDecoder(CuvidDecoder * decoder)
 	    ++decoder->FramesDropped;
 	    CuvidAdvanceDecoderFrame(decoder);
 	    decoder->SyncCounter = 1;
-	} else if (diff < lower_limit * 90 && !atomic_read(&decoder->SurfacesFilled) && !IsReplay()) {
+	} else if (diff < lower_limit * 90 && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced && !IsReplay()) {
 	    err = CuvidMessage(3, "video: speed up audio, delay audio\n");
 	    AudioDelayms(-diff / 90 + 55);
 	}

--- a/video.c
+++ b/video.c
@@ -6850,22 +6850,20 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
     }
 
   skip_sync:
-    // check if next field is available
-    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) <= 1) {
-	if (atomic_read(&decoder->SurfacesFilled) == 1) {
-	    ++decoder->FramesDuped;
-	    // FIXME: don't warn after stream start, don't warn during pause
-	    err =
-		VaapiMessage(3,
-		_("video: decoder buffer empty, "
-		    "duping frame (%d/%d) %d v-buf\n"), decoder->FramesDuped,
-		decoder->FrameCounter, VideoGetBuffers(decoder->Stream));
-	    // some time no new picture or black video configured
-	    if (decoder->Closing < -300 || (VideoShowBlackPicture
-		    && decoder->Closing)) {
-		// clear ring buffer to trigger black picture
-		atomic_set(&decoder->SurfacesFilled, 0);
-	    }
+    // is it not possible, to advance the surface and/or the field?
+    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced) {
+	++decoder->FramesDuped;
+	// FIXME: don't warn after stream start, don't warn during pause
+	err =
+	    VaapiMessage(3,
+	    _("video: decoder buffer empty, "
+		"duping frame (%d/%d) %d v-buf\n"), decoder->FramesDuped,
+	    decoder->FrameCounter, VideoGetBuffers(decoder->Stream));
+	// some time no new picture or black video configured
+	if (decoder->Closing < -300 || (VideoShowBlackPicture
+	    && decoder->Closing)) {
+	    // clear ring buffer to trigger black picture
+	    atomic_set(&decoder->SurfacesFilled, 0);
 	}
 	goto out;
     }
@@ -10998,22 +10996,20 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
     }
 
   skip_sync:
-    // check if next field is available
-    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) <= 1 + 2 * decoder->Interlaced) {
-	if (atomic_read(&decoder->SurfacesFilled) == 1 + 2 * decoder->Interlaced) {
-	    ++decoder->FramesDuped;
-	    // FIXME: don't warn after stream start, don't warn during pause
-	    err =
-		VdpauMessage(3,
-		_("video: decoder buffer empty, "
-		    "duping frame (%d/%d) %d v-buf closing %d\n"), decoder->FramesDuped,
-		decoder->FrameCounter, VideoGetBuffers(decoder->Stream), decoder->Closing);
-	    // some time no new picture or black video configured
-	    if (decoder->Closing < -300 || (VideoShowBlackPicture
-		    && decoder->Closing)) {
-		// clear ring buffer to trigger black picture
-		atomic_set(&decoder->SurfacesFilled, 0);
-	    }
+    // is it not possible, to advance the surface and/or the field?
+    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced) {
+	++decoder->FramesDuped;
+	// FIXME: don't warn after stream start, don't warn during pause
+	err =
+	    VdpauMessage(3,
+	    _("video: decoder buffer empty, "
+	    "duping frame (%d/%d) %d v-buf closing %d\n"), decoder->FramesDuped,
+	    decoder->FrameCounter, VideoGetBuffers(decoder->Stream), decoder->Closing);
+	// some time no new picture or black video configured
+	if (decoder->Closing < -300 || (VideoShowBlackPicture
+	    && decoder->Closing)) {
+	    // clear ring buffer to trigger black picture
+	    atomic_set(&decoder->SurfacesFilled, 0);
 	}
 	goto out;
     }
@@ -13572,22 +13568,20 @@ static void CuvidSyncDecoder(CuvidDecoder * decoder)
     }
 
   skip_sync:
-    // check if next field is available
-    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) <= 1 + 2 * decoder->Interlaced) {
-	if (atomic_read(&decoder->SurfacesFilled) == 1 + 2 * decoder->Interlaced) {
-	    ++decoder->FramesDuped;
-	    // FIXME: don't warn after stream start, don't warn during pause
-	    err =
-		CuvidMessage(3,
-		_("video: decoder buffer empty, "
-		    "duping frame (%d/%d) %d v-buf closing %d\n"), decoder->FramesDuped,
-		decoder->FrameCounter, VideoGetBuffers(decoder->Stream), decoder->Closing);
-	    // some time no new picture or black video configured
-	    if (decoder->Closing < -300 || (VideoShowBlackPicture
-		    && decoder->Closing)) {
-		// clear ring buffer to trigger black picture
-		atomic_set(&decoder->SurfacesFilled, 0);
-	    }
+    // is it not possible, to advance the surface and/or the field?
+    if (decoder->SurfaceField && atomic_read(&decoder->SurfacesFilled) < 1 + 2 * decoder->Interlaced) {
+	++decoder->FramesDuped;
+	// FIXME: don't warn after stream start, don't warn during pause
+	err =
+	    CuvidMessage(3,
+	    _("video: decoder buffer empty, "
+	    "duping frame (%d/%d) %d v-buf closing %d\n"), decoder->FramesDuped,
+	    decoder->FrameCounter, VideoGetBuffers(decoder->Stream), decoder->Closing);
+	// some time no new picture or black video configured
+	if (decoder->Closing < -300 || (VideoShowBlackPicture
+	    && decoder->Closing)) {
+	    // clear ring buffer to trigger black picture
+	    atomic_set(&decoder->SurfacesFilled, 0);
 	}
 	goto out;
     }

--- a/video.c
+++ b/video.c
@@ -6794,7 +6794,7 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 		AudioFlushBuffers();
 		goto out;
 	    }
-	    if((video_clock < audio_clock - VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
+	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
 		Debug(3,"drop video\n");
 		VaapiAdvanceDecoderFrame(decoder);
 		goto skip_sync;
@@ -10940,7 +10940,7 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 		AudioFlushBuffers();
 		goto out;
 	    }
-	    if((video_clock < audio_clock - VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
+	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
 		Debug(3,"drop video\n");
 		VdpauAdvanceDecoderFrame(decoder);
 		goto skip_sync;
@@ -13512,7 +13512,7 @@ static void CuvidSyncDecoder(CuvidDecoder * decoder)
 		AudioFlushBuffers();
 		goto out;
 	    }
-	    if((video_clock < audio_clock - VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
+	    if((video_clock < audio_clock + VideoAudioDelay - 120 * 90) && !VideoSoftStartSync) {
 		Debug(3,"drop video\n");
 		CuvidAdvanceDecoderFrame(decoder);
 		goto skip_sync;


### PR DESCRIPTION
almost no more droping/duping after sync on SD:
The values are found by trial and error, and work well for my stations, you might need to adapt to your conditions.
This increases zapping time for SD though.
Maybe  VideoStartThreshold should be made setup config option?

replace filled by atomic_read(&decoder->SurfacesFilled) since there might already be new packets:
I have actually seen filled being outdated.