### PR TITLE
in case of fast sync or soft sync use old behaviour (part 2)

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -2506,7 +2506,7 @@ void AudioVideoReady(int64_t pts)
     if (!AudioRunning || IsReplay()) {
 	int skip;
 
-	skip = pts - audio_pts - VideoAudioDelay - (IsReplay() ? 0 : AudioBufferTime * 90) + (VideoResolution == VideoResolution576i && !IsReplay() ? 240 * 90 : 0);
+	skip = pts - audio_pts - VideoAudioDelay - (IsReplay() ? 0 : AudioBufferTime * 90) + (VideoResolution == VideoResolution576i && !IsReplay() && VideoSoftStartSync == 1 ? 240 * 90 : 0);
 #ifdef DEBUG
 	fprintf(stderr, "%dms %dms %dms\n", (int)(pts - audio_pts) / 90,
 	    VideoAudioDelay / 90, skip / 90);


### PR DESCRIPTION
make the commit 'almost no more droping/duping after sync on SD' depended on accurate sync